### PR TITLE
Redundant buffers

### DIFF
--- a/autoload/terminator.vim
+++ b/autoload/terminator.vim
@@ -5,10 +5,14 @@ let g:autoloaded_terminator = 1
 
 if exists("g:terminator_repl_command")
     let s:terminator_repl_command = extend(terminator#language_maps#repl_command, g:terminator_repl_command)
+else
+    let s:terminator_repl_command = terminator#language_maps#repl_command
 endif
 
 if exists("g:terminator_runfile_map")
     let s:terminator_runfile_map = extend(terminator#language_maps#runfile_map, g:terminator_runfile_map)
+else
+    let s:terminator_runfile_map = terminator#language_maps#runfile_map
 endif
 
 " used in plugin/terminator.vim

--- a/autoload/terminator/jobs.vim
+++ b/autoload/terminator/jobs.vim
@@ -61,12 +61,12 @@ function terminator#jobs#nvim_on_event(job_id, data, event) dict
         call appendbufline(s:output_buf_num, '$', '')
         if a:data == 0
             let l:str = '[Done] in '  . run_time . ' seconds'
+            call terminator#window#output_buffer_shrink()
         else
             call terminator#window#output_buffer_close()
             let l:str = '[Done] in '  . run_time . ' seconds with code=' . string(a:data)
         endif
         botright cwindow
-        " call terminator#window#output_buffer_shrink()
         if a:data != 0
             copen
         endif
@@ -80,12 +80,16 @@ function terminator#jobs#vim_on_exit(channel, data)
     call appendbufline(s:output_buf_num, '$', '')
     if a:data == 0
         let l:str = '[Done] in '  . run_time . ' seconds'
+        call terminator#window#output_buffer_shrink()
     else
+        call terminator#window#output_buffer_close()
         let l:str = '[Done] in '  . run_time . ' seconds with code=' . string(a:data)
     endif
     call appendbufline(s:output_buf_num, '$', l:str)
     botright cwindow
-    call terminator#window#output_buffer_shrink()
+    if a:data != 0
+        copen
+    endif
 endfunction
 
 function terminator#jobs#vim_on_error(channel, data)

--- a/plugin/terminator.vim
+++ b/plugin/terminator.vim
@@ -10,7 +10,7 @@ command! -nargs=+ TerminatorSendToTerminal call terminator#window#send_to_termin
 command! TerminatorRunFileInTerminal call terminator#run_file("terminal", expand("%"))
 command! TerminatorRunFileInOutputBuffer call terminator#run_file("output_buffer", expand("%"))
 command! TerminatorStopRun call terminator#jobs#stop_running_job()
-command! -nargs=+ TerminatorRunAltCmd call terminator#run_file_in_output_buffer(<q-args>)
+command! -nargs=+ TerminatorRunAltCmd call terminator#jobs#run_file_in_output_buffer(<q-args>)
 command! TerminatorToggleOutputBuffer call terminator#window#output_buffer_toggle()
 
 command! -range TerminatorSendSelectionToTerminal call terminator#window#send_to_terminal(terminator#util#get_visual_selection())


### PR DESCRIPTION
Made the same changes to vim as were done for neovim in the last PR. That is, on non-zero exit code, close the output buffer and open the quickfix list.